### PR TITLE
Confirm timeout functionality added

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This document try to explore available without sophisticated scenarios like serv
 
 For the sake of demo, we will use [Containerlab][clab] as brilliant network simulation tool and dedicated clab setup published together with JSON RPC package [lab][lab].
 The same virtual lab is used to perform integration testing as well as for client sample implementation.
-The setup can be ramped-up by using `sudo clab deploy` command.
+The setup can be ramped-up by using `cd _clab` followed by `sudo clab deploy` command.
 Our simple program will grow up each and every steps allowing to have necessary grip with the subject API.
 It does not pretend to be comprehensive, but overall should be easy to learn. Over the next releases we will further extend it based on users feedback.
 

--- a/_clab/nokia-evpn.clab.yml
+++ b/_clab/nokia-evpn.clab.yml
@@ -3,7 +3,7 @@ name: evpn
 topology:
   kinds:
     srl:
-      image: ghcr.io/nokia/srlinux:23.3.1
+      image: ghcr.io/nokia/srlinux:23.3.2
     linux:
       image: ghcr.io/hellt/network-multitool
 

--- a/apierr/errors.go
+++ b/apierr/errors.go
@@ -34,6 +34,9 @@ const (
 	ErrClntTLSLoadCAPEM
 	ErrClntTLSLoadCertPair
 	ErrClntTLSCertParsing
+	ErrClntCBFuncLowerThanCT
+	ErrClntCBFuncIsNil
+	ErrClntCBFuncExec
 )
 
 const (
@@ -55,11 +58,13 @@ const (
 	ErrMsgDSCandidateValidateOnly
 	ErrMsgDSCandidateDiffOnly
 	ErrMsgDSSpecNotAllowedForUnknownMethod
-	ErrMsgCLISettingMethod    // Contains underlying error.
-	ErrMsgCLIAddingCmdsInReq  // Contains underlying error.
-	ErrMsgCLISettingOutFormat // Contains underlying error.
-	ErrMsgCLIMarshalling      // Contains underlying error.
-	ErrMsgRespMarshalling     // Contains underlying error.
+	ErrMsgCLISettingMethod         // Contains underlying error.
+	ErrMsgCLIAddingCmdsInReq       // Contains underlying error.
+	ErrMsgCLISettingOutFormat      // Contains underlying error.
+	ErrMsgCLIMarshalling           // Contains underlying error.
+	ErrMsgRespMarshalling          // Contains underlying error.
+	ErrMsgReqSettingConfirmTimeout // Contains underlying error.
+	ErrMsgReqSettingDSParams       // Contains underlying error.
 )
 
 type ClientError struct {
@@ -118,6 +123,12 @@ func (e ClientError) Error() string {
 		m = "can't load PEM file for certificate / key pair"
 	case ErrClntTLSCertParsing:
 		m = "certificate parsing error"
+	case ErrClntCBFuncLowerThanCT:
+		m = "callback timeout must be lower than confirm timeout"
+	case ErrClntCBFuncIsNil:
+		m = "callback function is nil"
+	case ErrClntCBFuncExec:
+		m = "callback function execution error"
 	default:
 		m = "incorrect code error"
 	}
@@ -201,6 +212,10 @@ func (e MessageError) Error() string {
 		m = "marshalling error"
 	case ErrMsgRespMarshalling:
 		m = "marshalling error"
+	case ErrMsgReqSettingConfirmTimeout:
+		m = "error setting confirm timeout"
+	case ErrMsgReqSettingDSParams:
+		m = "error setting datastore parameters, check underlying error"
 	default:
 		m = "incorrect code error"
 	}

--- a/commands.go
+++ b/commands.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/azyablov/srljrpc/actions"
+	"github.com/azyablov/srljrpc/ctimeout"
 	"github.com/azyablov/srljrpc/datastores"
 	"github.com/azyablov/srljrpc/formats"
 	"github.com/azyablov/srljrpc/yms"
@@ -12,6 +13,9 @@ import (
 
 // CommandOption type to represent a function that configures a Command.
 type CommandOption func(*Command) error
+
+// CommandValue type to represent a value of a command.
+type CommandValue string
 
 // Constructor for a new Command object with mandatory action, path and value fields, and optional command options to influence command behavior.
 func NewCommand(action actions.EnumActions, path string, value CommandValue, opts ...CommandOption) (*Command, error) {
@@ -113,16 +117,14 @@ func (c *Command) withDatastore(ds datastores.EnumDatastores) error {
 	return c.Datastore.SetDatastore(ds)
 }
 
-// CommandValue type to represent a value of a command.
-type CommandValue string
-
 // Params defines a container for Commands and optional OutputFormat and Datastore objects.
-// Params embeds OutputFormat and Datastore objects.
+// Params embeds: OutputFormat, Datastore objects and ConfirmTimeout (used for confirmed commits).
 type Params struct {
 	Commands []Command `json:"commands"`
 	*formats.OutputFormat
 	*datastores.Datastore
 	*yms.YmType
+	*ctimeout.ConfirmTimeout
 }
 
 // Append commands to the params. Internal method.
@@ -146,6 +148,12 @@ func (p *Params) withDatastore(ds datastores.EnumDatastores) error {
 func (p *Params) withYmType(ym yms.EnumYmType) error {
 	p.YmType = &yms.YmType{}
 	return p.SetYmType(ym)
+}
+
+// Set confirm timeout for the params. Internal method.
+func (p *Params) withConfirmTimeout(t int) error {
+	p.ConfirmTimeout = &ctimeout.ConfirmTimeout{}
+	return p.SetTimeout(t)
 }
 
 // CLIParams defines a container for CLI commands and optional OutputFormat object.

--- a/commands_int_test.go
+++ b/commands_int_test.go
@@ -107,7 +107,7 @@ func Test_withPathKeywords(t *testing.T) {
 	}
 
 	err := mockGetCmd.withPathKeywords([]byte(`{"name": "mgmt0", "name1": "mgmt1", "name2" "mgmt2"}`))
-	t.Logf("expected error: %s", err)
+	//t.Logf("expected error: %s", err)
 	if err == nil {
 		t.Fatalf("expected error 'failed to unmarshal path-keywords', got nil")
 	}

--- a/ctimeout/ctimeout.go
+++ b/ctimeout/ctimeout.go
@@ -1,0 +1,20 @@
+package ctimeout
+
+import "fmt"
+
+// Confirm timeout value for the Request method,in seconds. Nested under Params.
+type ConfirmTimeout struct {
+	Timeout int `json:"confirm-timeout,omitempty"`
+}
+
+func (c *ConfirmTimeout) GetTimeout() int {
+	return c.Timeout
+}
+
+func (c *ConfirmTimeout) SetTimeout(t int) error {
+	if t <= 0 {
+		return fmt.Errorf("confirm-timeout should be positive integer")
+	}
+	c.Timeout = t
+	return nil
+}


### PR DESCRIPTION
- cosmetic changes
- bump SRL up to 23.3.2
- add new errors related to confirm timeout
- confirm timeout objects
- add confirm timeout
- removed unnecessary Logf
- added SetConfirmTimeout and WithConfirmTimeout
- Extended tests with confirm timeout
- Extended Update/Replace/Delete/BuldSet with confirm timeout, added BulkSetCallBack to support || validation testing and callback verificaton for CI pipelines
- Extended tests with confirm timeout and added spcific tests for BulkSetCallBack
